### PR TITLE
Clean: *room-id* special var refactoring handle-event generic

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,0 +1,18 @@
+* Granolin
+
+Build better bots, for matrix!
+
+* Event Handlers
+** Special Variables
+*** *room-id*
+
+The special variable =*room-id*= is available in your =handle-event= methods.
+It will have the value of the Matrix room id in which the event occured. It
+will be =nil= if the event is not a room state nor timeline/message event.
+
+For example:
+
+#+begin_src common-lisp
+(defmethod handle-event :after ((cli echo-bot) (ev text-message-event)) 
+    (send-text-message cli *room-id* (msg-body ev)))
+#+end_src

--- a/package.lisp
+++ b/package.lisp
@@ -88,4 +88,6 @@
    #:start
    #:stop
 
+   ;; special variables
+   #:*room-id*
    ))


### PR DESCRIPTION
This addresses the conversation in issue #1 . I went ahead and created the readme
file to document the `*room-id*` variable. Also this commit removes the
hardcoded value for the roshamo example bot, and provides a function to create
and login your roshambot instead.